### PR TITLE
Implemented transaction isolation level support for PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     - sudo update-alternatives --quiet --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9 --slave /usr/bin/gcov gcov /usr/bin/gcov-4.9
     - sudo update-alternatives --quiet --set gcc /usr/bin/gcc-4.9
     - cd ..
-    - git clone --branch isolation_level --depth 1 https://github.com/volka/sqlpp11.git
+    - git clone --branch master --depth 1 https://github.com/rbock/sqlpp11.git
     - cd sqlpp11
     - cmake . -DHinnantDate_ROOT_DIR="$PWD/../date"
     - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ install:
     - wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION_MM}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.sh
     - sudo sh cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    - sudo add-apt-repository -y ppa:apokluda/boost1.53
+    - sudo add-apt-repository -y ppa:boost-latest/ppa
     - sudo apt-get update -qq
-    - sudo apt-get install g++-4.9 libboost1.53-dev libpq-dev postgresql-server-dev-all --no-install-recommends
+    - sudo apt-get install g++-4.9 libboost1.55-dev libpq-dev postgresql-server-dev-all --no-install-recommends
     - sudo update-alternatives --quiet --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6 --slave /usr/bin/gcov gcov /usr/bin/gcov-4.6
     - sudo update-alternatives --quiet --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9 --slave /usr/bin/gcov gcov /usr/bin/gcov-4.9
     - sudo update-alternatives --quiet --set gcc /usr/bin/gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     - sudo update-alternatives --quiet --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9 --slave /usr/bin/gcov gcov /usr/bin/gcov-4.9
     - sudo update-alternatives --quiet --set gcc /usr/bin/gcc-4.9
     - cd ..
-    - git clone --branch develop --depth 1 https://github.com/rbock/sqlpp11.git
+    - git clone --branch isolation_level --depth 1 https://github.com/volka/sqlpp11.git
     - cd sqlpp11
     - cmake . -DHinnantDate_ROOT_DIR="$PWD/../date"
     - sudo make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,41 @@ project(sqlpp11-connector-postgresql VERSION 0.1 LANGUAGES CXX)
 
 set(ConfigPackageLocation lib/cmake/sqlpp-postgresql)
 
-find_package(Sqlpp11 REQUIRED)
+#find_package(Sqlpp11 REQUIRED)
 find_package(PostgreSQL REQUIRED)
 
+set(DATE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../date" CACHE FILEPATH "Path to Howard Hinnant's date library")
+
+if(NOT EXISTS ${DATE_INCLUDE_DIR}/date.h)
+    message(SEND_ERROR "Can't find file date.h")
+    message("Please either")
+    message("  - git clone https://github.com/howardhinnant/date ${DATE_INCLUDE_DIR}")
+    message("  - download and unzip a current version from https://github.com/howardhinnant/date to ${DATE_INCLUDE_DIR}")
+    message("  = set DATE_INCLUDE_DIR to point to the dir containing date.h from the date library")
+    message("")
+else()
+    message("including date from ${DATE_INCLUDE_DIR}")
+endif()
+
+set(SQLPP11_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../sqlpp11/include" CACHE FILEPATH "Path to sqlpp11 includes")
+
+if(NOT EXISTS ${SQLPP11_INCLUDE_DIR}/sqlpp11/sqlpp11.h)
+    message(SEND_ERROR "Can't find file sqlpp11/sqlpp11.h")
+    message("Can't find sqlpp11/sqlpp11.h in ${SQLPP11_INCLUDE_DIR} ")
+    message("Please either")
+    message("  - git clone https://github.com/rbock/sqlpp11 ${SQLPP11_INCLUDE_DIR}")
+    message("  - download and unzip a current version from https://github.com/rbock/sqlpp11 to ${SQLPP11_INCLUDE_DIR}")
+    message("  - set DATE_INCLUDE_DIR to point to the dir containing sqlpp11/sqlpp11.h")
+    message("")
+else()
+    message("including sqlpp11 from ${SQLPP11_INCLUDE_DIR}")
+endif()
+
+include_directories("${SQLPP11_INCLUDE_DIR}")
+include_directories("${DATE_INCLUDE_DIR}")
+
 add_subdirectory(src)
-#add_subdirectory(tests)
+add_subdirectory(tests)
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/sqlpp11" DESTINATION include COMPONENT Devel)
 install(

--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -29,6 +29,7 @@
 #define SQLPP_POSTGRESQL_CONNECTION_H
 
 #include <sqlpp11/connection.h>
+#include <sqlpp11/transaction.h>
 #include <sqlpp11/serialize.h>
 #include <sqlpp11/postgresql/connection_config.h>
 #include <sqlpp11/postgresql/bind_result.h>
@@ -308,7 +309,7 @@ namespace sqlpp
       }
 
       //! start transaction
-      void start_transaction();
+      void start_transaction(isolation_level = isolation_level::undefined);
 
       //! commit transaction (or throw transaction if transaction has
       // finished already)

--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -308,8 +308,14 @@ namespace sqlpp
         return _prepare(t, sqlpp::prepare_check_t<_serializer_context_t, T>{});
       }
 
+      //! set the default transaction isolation level to use for new transactions
+      void set_default_isolation_level(isolation_level level);
+
+      //! get the currently set default transaction isolation level
+      isolation_level get_default_isolation_level();
+
       //! start transaction
-      void start_transaction(isolation_level = isolation_level::undefined);
+      void start_transaction(isolation_level level = isolation_level::undefined);
 
       //! commit transaction (or throw transaction if transaction has
       // finished already)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(sqlpp-postgresql SHARED
 target_compile_features(sqlpp-postgresql PRIVATE
 	cxx_auto_type)
 
-target_link_libraries(sqlpp-postgresql PUBLIC sqlpp11 PRIVATE ${PostgreSQL_LIBRARIES})
+target_link_libraries(sqlpp-postgresql PRIVATE ${PostgreSQL_LIBRARIES})
 
 target_include_directories(sqlpp-postgresql PRIVATE ${PostgreSQL_INCLUDE_DIRS} "../include/")
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -300,15 +300,46 @@ namespace sqlpp
     }
 
     //! start transaction
-    void connection::start_transaction()
+    void connection::start_transaction(isolation_level isolation_level)
     {
       if (_transaction_active)
       {
         throw sqlpp::exception("PostgreSQL error: transaction already open");
       }
 
-      auto prepared = prepare_statement(*_handle, "BEGIN", 0);
-      execute_statement(*_handle, prepared);
+      switch (isolation_level)
+      {
+      case isolation_level::serializable:
+        {
+          auto prepared = prepare_statement(*_handle, "BEGIN ISOLATION LEVEL SERIALIZABLE", 0);
+          execute_statement(*_handle, prepared);
+          break;
+        }
+      case isolation_level::repeatable_read:
+        {
+          auto prepared = prepare_statement(*_handle, "BEGIN ISOLATION LEVEL REPEATABLE READ", 0);
+          execute_statement(*_handle, prepared);
+          break;
+        }
+      case isolation_level::read_committed:
+        {
+          auto prepared = prepare_statement(*_handle, "BEGIN ISOLATION LEVEL READ COMMITTED", 0);
+          execute_statement(*_handle, prepared);
+          break;
+        }
+      case isolation_level::read_uncommitted:
+        {
+          auto prepared = prepare_statement(*_handle, "BEGIN ISOLATION LEVEL READ UNCOMMITTED", 0);
+          execute_statement(*_handle, prepared);
+          break;
+        }
+      case isolation_level::undefined:
+        {
+          auto prepared = prepare_statement(*_handle, "BEGIN", 0);
+          execute_statement(*_handle, prepared);
+          break;
+        }
+      }
       _transaction_active = true;
     }
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -26,6 +26,7 @@
  */
 
 #include <sqlpp11/postgresql/connection.h>
+#include <sqlpp11/transaction.h>
 #include <sqlpp11/exception.h>
 
 #include <algorithm>
@@ -300,14 +301,14 @@ namespace sqlpp
     }
 
     //! start transaction
-    void connection::start_transaction(isolation_level isolation_level)
+    void connection::start_transaction(sqlpp::isolation_level level)
     {
       if (_transaction_active)
       {
         throw sqlpp::exception("PostgreSQL error: transaction already open");
       }
 
-      switch (isolation_level)
+      switch (level)
       {
       case isolation_level::serializable:
         {

--- a/tests/BasicTest.cpp
+++ b/tests/BasicTest.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Volker Aßmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdexcept>
+#include <memory>
+#include <cassert>
+
+#include <sqlpp11/postgresql/connection.h>
+#include <sqlpp11/sqlpp11.h>
+
+namespace sql = sqlpp::postgresql;
+int main()
+{
+  auto config = std::make_shared<sql::connection_config>();
+  config->host = "localhost";
+  try {
+    sql::connection db(config);
+
+    throw std::logic_error("should never reach this point");
+  } catch (const sqlpp::exception& ex) {
+      assert(ex.what() == std::string("PostgreSQL error: failed to connect to the database"));
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ macro (build_and_run arg)
 	target_link_libraries(Sqlpp11PostgreSQL${arg} sqlpp-postgresql)
     include_directories("../include")
 	add_test(${arg} Sqlpp11PostgreSQL${arg})
+    target_compile_features(sqlpp-postgresql PRIVATE cxx_auto_type)
 endmacro ()
 
 build_and_run(BasicTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ macro (build_and_run arg)
 	target_link_libraries(Sqlpp11PostgreSQL${arg} sqlpp-postgresql)
     include_directories("../include")
 	add_test(${arg} Sqlpp11PostgreSQL${arg})
-    target_compile_features(sqlpp-postgresql PRIVATE cxx_auto_type)
+    target_compile_features(Sqlpp11PostgreSQL${arg} PRIVATE cxx_auto_type)
 endmacro ()
 
 build_and_run(BasicTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,9 @@ macro (build_and_run arg)
 	# Add headers to sources to enable file browsing in IDEs
 	add_executable(Sqlpp11PostgreSQL${arg} ${arg}.cpp ${sqlpp_headers})
 	target_link_libraries(Sqlpp11PostgreSQL${arg} sqlpp-postgresql)
+    include_directories("../include")
 	add_test(${arg} Sqlpp11PostgreSQL${arg})
 endmacro ()
 
-build_and_run(SelectTest)
+build_and_run(BasicTest)
+#build_and_run(TransactionTest)

--- a/tests/TransactionTest.cpp
+++ b/tests/TransactionTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, Volker Aßmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdexcept>
+#include <memory>
+#include <cassert>
+#include <iostream>
+
+#include <sqlpp11/sqlpp11.h>
+#include <sqlpp11/alias_provider.h>
+#include <sqlpp11/transaction.h>
+#include <sqlpp11/custom_query.h>
+#include <sqlpp11/postgresql/connection.h>
+
+namespace sql = sqlpp::postgresql;
+
+SQLPP_ALIAS_PROVIDER(level);
+
+int main()
+{
+  auto config = std::make_shared<sql::connection_config>();
+  config->host = "/var/run/postgresql";
+  try {
+    sql::connection db(config);
+
+    auto current_level = db(custom_query(sqlpp::verbatim("show transaction_isolation;"))
+            .with_result_type_of(select(sqlpp::value("").as(level))))
+        .front().level;
+    assert(current_level == "read committed");
+    std::cerr << "isolation level outside transaction: " << current_level << "\n";
+
+    auto tx = start_transaction(db, sqlpp::isolation_level::serializable);
+
+    current_level = db(custom_query(sqlpp::verbatim("show transaction_isolation;"))
+            .with_result_type_of(select(sqlpp::value("").as(level))))
+        .front().level;
+    assert(current_level == "serializable");
+    std::cerr << "isolation level in transaction(serializable) : " << current_level << "\n";
+
+  } catch (const sqlpp::exception& ex) {
+      std::cerr << "Got exception as expected: " << ex.what() << std::endl;
+      assert(ex.what() == std::string("PostgreSQL error: failed to connect to the database"));
+  }
+}


### PR DESCRIPTION
Implementation of transaction isolation level selection in start_transaction() for PostgreSQL, see the SQLPP11 pull request

https://github.com/rbock/sqlpp11/pull/171

for the overall interface.

I also fixed up the CMakeLists.txt to use the same mechanism as the SQLite connector to find sqlpp11 as "find_package" does not seem to work with the current version, and re-added a BasicTest that just checks if we fail to connect (but that will at least check if we can build a test binary)