### PR TITLE
ddl2cpp.py: Add support for nested namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,25 @@ Branch / Compiler | gcc 4.8 | MSVC 2015/2017
 master | [![Build Status](https://travis-ci.org/matthijs/sqlpp11-connector-postgresql.svg?branch=master)](https://travis-ci.org/matthijs/sqlpp11-connector-postgresql?branch=master) | [![Build status](https://ci.appveyor.com/api/projects/status/bmor62aunb03hoeg/branch/master?svg=true)](https://ci.appveyor.com/project/matthijs/sqlpp11-connector-postgresql)
 develop | [![Build Status](https://travis-ci.org/matthijs/sqlpp11-connector-postgresql.svg?branch=develop)](https://travis-ci.org/matthijs/sqlpp11-connector-postgresql?branch=develop) | [![Build status](https://ci.appveyor.com/api/projects/status/bmor62aunb03hoeg/branch/develop?svg=true)](https://ci.appveyor.com/project/matthijs/sqlpp11-connector-postgresql)
 
-Fork Info
-===========
+Examples
+========
 
-This is a fork of the sqlpp11-connector-postgresql repository by matthijs. It adds the following features:
+An example on how to use this library
+```c++
+auto config = std::make_shared<sqlpp::postgresql::connection_config>();
+config->host = "127.0.0.1";
+config->user = "someuser";
+config->password = "some-random-password";
+config->dbname = "somedb";
 
-* impement a "dynamic loading" variant which loads the libpq library using dlopen / LoadLibrary. Link agsinst the 
-  sqlpp-postgresql-dynamic.so library (and other connectors, e.g. sqlpp-sqlite3-dynamic) to support both databases 
-  in one binary without requiring all the different database client libraries to be installed.
+sqlpp::postgresql::connection db(config);
 
-* implement sqlpp11 std::chrono / "Hinnant Date" based date/time handling
+TabFoo foo;
+for(const auto& row: db(select(foo.name, foo.hasFun).from(foo).where(foo.id > 17 and foo.name.like("%bar%"))) {
+  std::cerr << row.name << std::endl;
+}
+```
 
-* implement support for setting isolation levels for transactions
-
-* implements missing connection::execute() function
-
-* implemented "integration tests" that will work with a local PostgreSQL DB where a database with the name "$USER" 
-  is present and the $USER can login via "peer" authentication. Use "cmake -DENABLE\_TESTS=True ..." to build tests.
-
-* some minor cleanups and optimizations
+Connection configuration
+========================
+You can use all possible authentication options that are available in PostgreSQL. See [here](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING) for more information about the options.

--- a/scripts/ddl2cpp.py
+++ b/scripts/ddl2cpp.py
@@ -2,10 +2,11 @@
 #
 # Generate C++ structs for the tables.
 
+import argparse
 import os
 import sys
 import psycopg2
-import argparse
+import re
 
 # Generate a argument parser
 parser = argparse.ArgumentParser(description='Create C++ structs from a database table structure.')
@@ -17,11 +18,12 @@ parser.add_argument('-o', '--output-dir', dest='outputdir', help='Output directo
 parser.add_argument('-n', '--namespace', dest='namespace', help='C++ namespace', default='model')
 args = parser.parse_args()
 
+def _getIncludeGuard(namespace, table):
+    val = re.sub("[^A-Za-z0-9]+", "_", namespace + "_" + table + "_h")
+    return val.upper()
+
 def _writeLine(fd, indent, line):
     fd.write(("\t" * indent) + line + "\n")
-
-def _getIncludeGuard(namespace, table):
-    return namespace.upper() + "_" + table.upper() + "_H"
 
 # SQL types
 types = {
@@ -39,7 +41,7 @@ types = {
     'double': 'floating_point',
     'float': 'floating_point',
     'numeric': 'floating_point',
-    
+
     'json' : 'text',
     'jsonb' : 'text',
 
@@ -54,6 +56,8 @@ types = {
     'USER-DEFINED': 'varchar',
 }
 
+nsList = args.namespace.split('::')
+
 # Connect to the database and fetch information from the information_schema
 # schema
 conn = psycopg2.connect("host=" + args.host + " user=" + args.user + " password=" + args.password + " dbname=" + args.dbname)
@@ -67,11 +71,13 @@ for table in tables:
     _writeLine(fd, 0, "#ifndef " + _getIncludeGuard(args.namespace, table[0]))
     _writeLine(fd, 0, "#define " + _getIncludeGuard(args.namespace, table[0]))
     _writeLine(fd, 0, "")
+    _writeLine(fd, 0, "")
     _writeLine(fd, 0, "#include <sqlpp11/table.h>")
     _writeLine(fd, 0, "#include <sqlpp11/char_sequence.h>")
     _writeLine(fd, 0, "#include <sqlpp11/column_types.h>")
     _writeLine(fd, 0, "")
-    _writeLine(fd, 0, "namespace " + args.namespace + " {")
+    for ns in nsList:
+        _writeLine(fd, 0, "namespace " + ns + " {")
     _writeLine(fd, 0, "")
     _writeLine(fd, 1, "namespace " + table[0] + "_ {")
 
@@ -140,7 +146,8 @@ for table in tables:
     _writeLine(fd, 1, "};")
 
     # end of namespace
-    _writeLine(fd, 0, "}")
+    for ns in nsList:
+        _writeLine(fd, 0, "} // namespace " + ns)
     _writeLine(fd, 0, "")
     _writeLine(fd, 0, "#endif")
 


### PR DESCRIPTION
In particular this script formerly didn't support namespaces of the form
`namespace_a::namespace_b`.