### PR TITLE
ddl2cpp.py: Fix ordering of closing namespace comments.

### DIFF
--- a/scripts/ddl2cpp.py
+++ b/scripts/ddl2cpp.py
@@ -146,7 +146,7 @@ for table in tables:
     _writeLine(fd, 1, "};")
 
     # end of namespace
-    for ns in nsList:
+    for ns in reversed(nsList):
         _writeLine(fd, 0, "} // namespace " + ns)
     _writeLine(fd, 0, "")
     _writeLine(fd, 0, "#endif")


### PR DESCRIPTION
In my earlier change I did not order the closing namespace comments
correctly.

For example before it would generate:
```
namespace a {
namespace b {
} // namespace a
} // namespace b
```

The correct order is:
```
namespace a {
namespace b {
} // namespace b
} // namespace a
```