### PR TITLE
Removed unecessary boost requirements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,8 @@ set(ConfigPackageLocation lib/cmake/sqlpp-connector-postgresql)
 
 find_package(Sqlpp11 REQUIRED)
 find_package(PostgreSQL REQUIRED)
-find_package(Boost REQUIRED)
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
-include_directories(${Boost_INCLUDE_DIRS})
 
 add_subdirectory(src)
 

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -36,8 +36,6 @@
 
 #include <sqlpp11/postgresql/visibility.h>
 
-#include <boost/lexical_cast.hpp>
-
 namespace sqlpp
 {
   namespace postgresql
@@ -66,12 +64,10 @@ namespace sqlpp
         static_assert(std::is_arithmetic<T>::value, "Value must be numeric type");
         checkIndex(record, field);
         T t(0);
-        try
+        auto txt = std::string(PQgetvalue(m_result, record, field));
+        if(txt != "")
         {
-          t = boost::lexical_cast<T>(PQgetvalue(m_result, record, field));
-        }
-        catch (boost::bad_lexical_cast)
-        {
+          t = std::stold(txt);
         }
         return t;
       }

--- a/src/detail/prepared_statement_handle.cpp
+++ b/src/detail/prepared_statement_handle.cpp
@@ -1,4 +1,5 @@
 #include "prepared_statement_handle.h"
+#include <algorithm>
 #include <random>
 #include <sqlpp11/postgresql/connection_config.h>
 

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -29,6 +29,7 @@
 #include <sqlpp11/postgresql/exception.h>
 #include <sqlpp11/postgresql/result.h>
 #include <string>
+#include <cstring>
 
 namespace sqlpp
 {
@@ -183,7 +184,7 @@ namespace sqlpp
       {
         const char* p = PQresultErrorField(m_result, PG_DIAG_STATEMENT_POSITION);
         if (p)
-          pos = boost::lexical_cast<int>(p);
+          pos = std::stoi(std::string(p));
       }
       return pos;
     }
@@ -203,7 +204,7 @@ namespace sqlpp
     int Result::affected_rows()
     {
       const char* const RowsStr = PQcmdTuples(m_result);
-      return RowsStr[0] ? boost::lexical_cast<int>(RowsStr) : 0;
+      return RowsStr[0] ? std::stoi(std::string(RowsStr)) : 0;
     }
 
     int Result::records_size() const


### PR DESCRIPTION
Hello @matthijs 

Boost is pretty big, I did try to compile only with [boost lexical_cast](https://github.com/boostorg/lexical_cast/) without success, so I did try to use the new c++11 stoi / stold functions and apparently they work fine, and all the tests pass.

If you find that useful, there are the (small) changes.