### PR TITLE
Use append for properties as generator expressions

### DIFF
--- a/cmake/Sqlpp-connector-postgresqlConfig.cmake
+++ b/cmake/Sqlpp-connector-postgresqlConfig.cmake
@@ -30,11 +30,13 @@ find_dependency(PostgreSQL REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp-connector-postgresqlTargets.cmake")
 
-set_target_properties(Sqlpp::sqlpp11-connector-postgresql PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${Sqlpp11_INCLUDE_DIRS};${PostgreSQL_INCLUDE_DIRS};$<TARGET_PROPERTY:INTERFACE_INCLUDE_DIRECTORIES>"
+set_property(TARGET Sqlpp::sqlpp11-connector-postgresql APPEND PROPERTY
+  INTERFACE_INCLUDE_DIRECTORIES "${Sqlpp11_INCLUDE_DIRS};${PostgreSQL_INCLUDE_DIRS}"
 )
 
-set_target_properties(Sqlpp::sqlpp11-connector-postgresql-dynamic PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${Sqlpp11_INCLUDE_DIRS};${PostgreSQL_INCLUDE_DIRS};$<TARGET_PROPERTY:INTERFACE_INCLUDE_DIRECTORIES>"
-  INTERFACE_LINK_LIBRARIES "${PostgreSQL_LIBRARIES};$<TARGET_PROPERTY:INTERFACE_LINK_LIBRARIES>"
+set_property(TARGET Sqlpp::sqlpp11-connector-postgresql-dynamic APPEND PROPERTY
+  INTERFACE_INCLUDE_DIRECTORIES "${Sqlpp11_INCLUDE_DIRS};${PostgreSQL_INCLUDE_DIRS}"
+)
+set_property(TARGET Sqlpp::sqlpp11-connector-postgresql-dynamic APPEND PROPERTY
+  INTERFACE_LINK_LIBRARIES "${PostgreSQL_LIBRARIES}"
 )

--- a/cmake/Sqlpp-connector-postgresqlConfig.cmake
+++ b/cmake/Sqlpp-connector-postgresqlConfig.cmake
@@ -33,6 +33,10 @@ include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp-connector-postgresqlTargets.cmake")
 set_property(TARGET Sqlpp::sqlpp11-connector-postgresql APPEND PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES "${Sqlpp11_INCLUDE_DIRS};${PostgreSQL_INCLUDE_DIRS}"
 )
+set_property(TARGET Sqlpp::sqlpp11-connector-postgresql APPEND PROPERTY
+  INTERFACE_LINK_LIBRARIES "${PostgreSQL_LIBRARIES}"
+)
+
 
 set_property(TARGET Sqlpp::sqlpp11-connector-postgresql-dynamic APPEND PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES "${Sqlpp11_INCLUDE_DIRS};${PostgreSQL_INCLUDE_DIRS}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ target_compile_options(sqlpp11-connector-postgresql-dynamic PRIVATE -DBUILDING_D
 target_compile_features(sqlpp11-connector-postgresql PRIVATE cxx_auto_type)
 target_compile_features(sqlpp11-connector-postgresql-dynamic PRIVATE cxx_auto_type)
 
-target_link_libraries(sqlpp11-connector-postgresql PRIVATE sqlpp11 ${PostgreSQL_LIBRARIES})
+target_link_libraries(sqlpp11-connector-postgresql PRIVATE sqlpp11 $<BUILD_INTERFACE:${PostgreSQL_LIBRARIES}>)
 target_link_libraries(sqlpp11-connector-postgresql-dynamic PUBLIC sqlpp11 PRIVATE ${PostgreSQL_LIBRARIES})
 
 target_include_directories(sqlpp11-connector-postgresql PRIVATE ${sqlpp11_INCLUDE_DIRS} ${PostgreSQL_INCLUDE_DIRS} "../include/")


### PR DESCRIPTION
sometimes evaluate to empty

As in title, the installed libraries could not always find the connector library and headers on windows. This fixes the issue