### PR TITLE
Fix: uncomment timezone shifting code in bind_result ; explicitely 'SET TIME ZONE' in tests to pass CI

### DIFF
--- a/tests/DateTest.cpp
+++ b/tests/DateTest.cpp
@@ -54,16 +54,16 @@ namespace
   template<class Db>
   void prepare_table(Db&& db, bool with_tz)
   {
+    db.execute("SET TIME ZONE 'UTC'");
+    db.execute("DROP TABLE IF EXISTS tab_date_time");
     if (with_tz)
     {
       // prepare test with timezone
-      db.execute("DROP TABLE IF EXISTS tab_date_time");
       db.execute("CREATE TABLE tab_date_time (col_day_point DATE, col_time_point TIMESTAMP WITH TIME ZONE)");
     }
     else
     {
     // prepare  test without timezone
-    db.execute("DROP TABLE IF EXISTS tab_date_time");
     db.execute("CREATE TABLE tab_date_time (col_day_point DATE, col_time_point TIMESTAMP)");
     }
   }

--- a/tests/DateTime.cpp
+++ b/tests/DateTime.cpp
@@ -86,7 +86,8 @@ int DateTime(int, char*[])
     std::cerr << "For testing, you'll need to create a database sqlpp_postgresql" << std::endl;
     throw;
   }
-
+  
+  db.execute(R"(SET TIME ZONE 'UTC';)");
   db.execute(R"(DROP TABLE IF EXISTS tabfoo;)");
   db.execute(R"(CREATE TABLE tabfoo
                (


### PR DESCRIPTION
This hopefully will fix travis CI.

Clang-format gave spurrious changes, I kept them since the project has a
clang-format file