### PR TITLE
Resolve hard-dependency on sqlpp11 being installed at a system level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(ConfigPackageLocation lib/cmake/sqlpp-connector-postgresql)
 
-find_package(Sqlpp11 REQUIRED)
+# Try to find the necessary files on the system installation if not already loaded via add_subdirectory() from parent project
+if (NOT TARGET sqlpp11)
+    find_package(Sqlpp11 REQUIRED)
+endif()
 find_package(PostgreSQL REQUIRED)
 
 include_directories("${PROJECT_SOURCE_DIR}/include")


### PR DESCRIPTION
I ran into a problem when trying to use this extension of sqlpp11. It would not load properly due to an extra dependency basically creating a linking/dependency hell to include the same module multiple times.

The change should not affect existing users who choose to install it on their system, but also allow people to use the postgresql connector without having to install sqlpp11 at a system level.

More information and the problem being resolved can be found here: https://github.com/rbock/sqlpp11/issues/137#issuecomment-605649761