### PR TITLE
Fix typo which lead to error when converting database in ddl2cpp.py script

### DIFF
--- a/scripts/ddl2cpp.py
+++ b/scripts/ddl2cpp.py
@@ -51,7 +51,7 @@ types = {
     'bool': 'boolean',
     'boolean': 'boolean',
     'double': 'floating_point',
-    'double precission': 'floating_point',
+    'double precision': 'floating_point',
     'float': 'floating_point',
     'numeric': 'floating_point',
     'decimal': 'floating_point',


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "thirdparty/sqlpp11-connector-postgresql/scripts/ddl2cpp.py", line 158, in <module>
    traits = "using _traits = ::sqlpp::make_traits<::sqlpp::" + types[column[7]]
KeyError: 'double precision'
```

Fixed a simple typo.