### PR TITLE
Add: binary blob support

### DIFF
--- a/include/sqlpp11/postgresql/bind_result.h
+++ b/include/sqlpp11/postgresql/bind_result.h
@@ -91,6 +91,7 @@ namespace sqlpp
       void _bind_boolean_result(size_t index, signed char* value, bool* is_null);
       void _bind_floating_point_result(size_t index, double* value, bool* is_null);
       void _bind_integral_result(size_t index, int64_t* value, bool* is_null);
+      void _bind_blob_result(size_t index, const uint8_t** value, size_t* len);
       void _bind_text_result(size_t index, const char** value, size_t* len);
       void _bind_date_result(size_t index, ::sqlpp::chrono::day_point* value, bool* is_null);
       void _bind_date_time_result(size_t index, ::sqlpp::chrono::microsecond_point* value, bool* is_null);

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -125,11 +125,7 @@ namespace sqlpp
     template <>
     inline const uint8_t* Result::getValue<const uint8_t*>(int record, int field) const 
     {
-      checkIndex(record, field);
-      int blen = PQgetlength(m_result, record, field);
-      // How to use blen here? Memcopy and create a new buffer
-      char* bptr = getPqValue(m_result, record, field);
-      return const_cast<const uint8_t*>(bptr);
+      return reinterpret_cast<const uint8_t*>(getValue<const char*>(record, field));
     }
   }
 }

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -121,6 +121,16 @@ namespace sqlpp
         return false;
       return const_cast<const char*>(val);
     }
+
+    template <>
+    inline const uint8_t* Result::getValue<const uint8_t*>(int record, int field) const 
+    {
+      checkIndex(record, field);
+      int blen = PQgetlength(m_result, record, field);
+      // How to use blen here? Memcopy and create a new buffer
+      char* bptr = getPqValue(m_result, record, field);
+      return const_cast<const uint8_t*>(bptr);
+    }
   }
 }
 

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -146,6 +146,27 @@ namespace sqlpp
       }
     }
 
+    void bind_result_t::_bind_blob_result(size_t index, const uint8_t** value, size_t* len)
+    {
+
+      auto index = static_cast<int>(_index);
+      if (_handle->debug())
+      {
+        std::cerr << "PostgreSQL debug: binding blob result at index: " << index << std::endl;
+      }
+
+      if (_handle->result.isNull(_handle->count, index))
+      {
+        *value = nullptr;
+        *len = 0;
+      }
+      else
+      {
+        *value = _handle->result.getValue<const uint8_t*>(_handle->count, index);
+        *len   = _handle->result.length(_handle->count, index);
+      }
+    }
+
     // same parsing logic as SQLite connector
     // PostgreSQL will return one of those (using the default ISO client):
     //

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -146,7 +146,7 @@ namespace sqlpp
       }
     }
 
-    void bind_result_t::_bind_blob_result(size_t index, const uint8_t** value, size_t* len)
+    void bind_result_t::_bind_blob_result(size_t _index, const uint8_t** value, size_t* len)
     {
 
       auto index = static_cast<int>(_index);


### PR DESCRIPTION
While using sqlpp11 with a table containing a binary blob data field, I run into the following error: 
` error: no member named '_bind_blob_result' in 'sqlpp::postgresql::bind_result_t'`

Hopefully this fixes that 

Thanks for you work! 