### PR TITLE
fix conversion of date time with timezone to localtime

### DIFF
--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -286,6 +286,10 @@ namespace sqlpp
       // escape argument
       std::string escape(const std::string& s) const;
 
+      // escape binary data
+      std::string escape_raw(const std::string& s) const;
+      std::string unescape_raw(const std::string& s) const;
+      
       //! call run on the argument
       template <typename T>
       auto _run(const T& t, sqlpp::consistent_t) -> decltype(t._run(*this))

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -257,6 +257,33 @@ namespace sqlpp
       return result;
     }
 
+	
+    std::string connection::escape_raw(const std::string& s) const
+    {
+      validate_connection_handle();
+      
+      unsigned long length;
+      const unsigned char *buff = PQescapeByteaConn(_handle->postgres, (const unsigned char *)s.data(), s.size(), &length);
+      if(nullptr == buff)
+	  return std::string{};
+      const std::string result((const char *)buff, length);
+      PQfreemem((void *)buff);
+      return result;
+    }
+    
+    std::string connection::unescape_raw(const std::string& s) const
+    {
+      validate_connection_handle();
+      
+      unsigned long length;
+      const unsigned char *buff = PQunescapeBytea((const unsigned char *)s.c_str(), &length);
+      if(nullptr == buff)
+	  return std::string{};
+      const std::string result((const char *)buff, length);
+      PQfreemem((void *)buff);
+      return result;
+    }
+    
     //! start transaction
     void connection::start_transaction(sqlpp::isolation_level level)
     {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -256,7 +256,6 @@ namespace sqlpp
       result.resize(length);
       return result;
     }
-
 	
     std::string connection::escape_raw(const std::string& s) const
     {


### PR DESCRIPTION
The connector is assuming that all dates I/O are local time, why not. 
The response contains dates in respect with the database timezone setting, to get the client local timezone value we must revert to UTC and then apply local timezone offset.
